### PR TITLE
Fix compatibility with vpype 1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click
-vpype
+vpype>=1.9,<2.0
 numpy
 pyembroidery

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     install_requires=[
         "click",
-        "vpype",
+        "vpype>=1.9,<2.0",
         "numpy",
         "pyembroidery",
     ],

--- a/vpype_embroidery/efill.py
+++ b/vpype_embroidery/efill.py
@@ -3,6 +3,7 @@ from math import isinf, isnan
 import click
 import numpy as np
 import vpype as vp
+import vpype_cli
 from svgelements import Point
 
 
@@ -10,7 +11,7 @@ from svgelements import Point
 @click.option(
     "-t",
     "--tolerance",
-    type=vp.LengthType(),
+    type=vpype_cli.LengthType(),
     default="0.01mm",
     help="Max distance between start and end point to consider a path closed "
     "(default: 0.01mm)",
@@ -18,11 +19,11 @@ from svgelements import Point
 @click.option(
     "-d",
     "--distance",
-    type=vp.LengthType(),
+    type=vpype_cli.LengthType(),
     default="0.4mm",
     help="Distance Between lines in the fill" "(default: 0.4mm)",
 )
-@vp.global_processor
+@vpype_cli.global_processor
 def efill(document: vp.Document, tolerance: float, distance: float):
     """
     Implements the Eulerian fill algorithm which fills any closed shapes with as few paths as there are contiguous

--- a/vpype_embroidery/eread.py
+++ b/vpype_embroidery/eread.py
@@ -1,15 +1,22 @@
+import pathlib
+
 import click
 import numpy as np
 import vpype as vp
+import vpype_cli
 from pyembroidery import EmbPattern
 
 _EMB_SCALE_FACTOR = 2.645833333333333
 
 
 @click.command()
-@click.argument("filename", type=click.Path(exists=True))
-@vp.global_processor
+@click.argument("filename", type=vpype_cli.PathType(exists=True))
+@vpype_cli.global_processor
 def eread(document: vp.Document, filename: str):
+    # populate the vp_source[s] properties
+    document.set_property(vp.METADATA_FIELD_SOURCE, pathlib.Path(filename).absolute())
+    document.add_to_sources(filename)
+
     pattern = EmbPattern(filename)
     for stitches, color in pattern.get_as_stitchblock():
         if len(stitches) == 0:
@@ -19,8 +26,8 @@ def eread(document: vp.Document, filename: str):
         stitch_block = np.asarray(stitches, dtype="float")
         stitch_block = stitch_block[..., 0] + 1j * stitch_block[..., 1]
         lc.append(stitch_block)
-        lc.emb_thread = color  # No defined color api.
-        document.add(lc)
+        lc.set_property(vp.METADATA_FIELD_COLOR, vp.Color(color.hex_color()))
+        document.add(lc, with_metadata=True)
     return document
 
 

--- a/vpype_embroidery/ewrite.py
+++ b/vpype_embroidery/ewrite.py
@@ -1,21 +1,22 @@
 import click
 import vpype as vp
+import vpype_cli
 from pyembroidery import COLOR_BREAK, SEQUENCE_BREAK, STITCH, EmbPattern
 
 _EMB_SCALE_FACTOR = 2.645833333333333
 
 
 @click.command()
-@click.argument("filename", type=click.Path(exists=False))
+@click.argument("filename", type=vpype_cli.PathType(exists=False))
 @click.option(
     "-v",
     "--version",
     nargs=1,
     default=None,
-    type=str,
+    type=vpype_cli.TextType(),
     help="version of embroidery file to write",
 )
-@vp.global_processor
+@vpype_cli.global_processor
 def ewrite(document: vp.Document, filename: str, version: str):
     pattern = EmbPattern()
     for layer in document.layers.values():


### PR DESCRIPTION
Done:
- pinned vpype to 1.9
- fixed vpype-related imports
- switched options to expression-compatible types
- added source file recording in `eread`
- added color support to `eread`

Notes:
- Color support should probably be added to `ewrite` but I'm unsure how to do that. The color of the current layer can be obtained with `layer.property(vp.METADATA_FIELD_COLOR)`. It returns `None` if undefined or a [`vp.Color` instance](https://github.com/abey79/vpype/blob/1071d6f8c9c904b40a55532e0426c11e2427c797/vpype/metadata.py#L8) otherwise.
- I'm unsure if reading/writing pen width and/or layer name would make sense too.
